### PR TITLE
DHLGW-1535: Add support for Magento 2.4.9 and PHP 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.4.0
+
+### Added
+
+- Support for Magento 2.4.9
+- Support for PHP 8.5
+
+### Removed
+
+- Support for PHP 7.2, 8.1 and 8.2
+- Support for Magento 2.4.4, 2.4.5, 2.4.6 and 2.4.7
+
 ## 1.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ for use in Magento 2 extensions with a system configuration section.
 
 ## Installation via composer
 
-Requires PHP >=7.0 and Magento >=2.2
+Requires PHP 8.3, 8.4 or 8.5 and Magento 2.4.8 or 2.4.9.
 
 ```bash
 composer require netresearch/config-fields-m2:*

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "netresearch/config-fields-m2",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "magento2-module",
   "description": "A collection of custom config types for Magento 2 system configuration development.",
   "license": "OSL-3.0",
@@ -11,10 +11,10 @@
     }
   ],
   "require": {
-    "magento/framework": "^102.0.0 || ^103.0.0",
-    "magento/module-backend": "^101.0.0 || ^102.0.0",
-    "magento/module-config": "^101.1.0",
-    "php": "^7.2.0 || ^8.1.0"
+    "magento/framework": "^103.0.8",
+    "magento/module-backend": "^102.0.8",
+    "magento/module-config": "^101.2.8",
+    "php": "^8.3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary

Bumps `netresearch/config-fields-m2` to **1.4.0** with explicit Magento 2.4.9 and PHP 8.5 support, dropping legacy versions.

## Changes

- **`composer.json`** constraints modernized:
  - `magento/framework`: `^102.0.0 || ^103.0.0` → `^103.0.8` (drops Magento 2.4.4 - 2.4.6, covers 2.4.8 + 2.4.9)
  - `magento/module-backend`: `^101.0.0 || ^102.0.0` → `^102.0.8`
  - `magento/module-config`: `^101.1.0` → `^101.2.8`
  - `php`: `^7.2.0 || ^8.1.0` → `^8.3.0 || ^8.4.0 || ^8.5.0`
  - `version`: `1.3.0` → `1.4.0`
- **`README.md`** install requirements aktualisiert: `Requires PHP 8.3, 8.4 or 8.5 and Magento 2.4.8 or 2.4.9`
- **`CHANGELOG.md`** Keep-a-Changelog `## 1.4.0` Eintrag (Added / Removed)

## Context

Teil der [DHLGW-1535](https://jira.netresearch.de/browse/DHLGW-1535) MINOR-Bump-Welle für die DHL-Shipping-Bundle (Magento 2.4.9 GA + PHP 8.5 Compat). Adobe-Standard *N + N-1* Support-Scope (siehe [Magento Release Notes 2.4.9](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/adobe-commerce/2-4-9)).

## Test plan

Empirisch bereits validiert via transitive Installation in unserer GitLab-CI: `dhl/module-carrier-paket` Pipeline 215516 / Job 532285 (`phpunit-8.5-ce2.4.9`) hat `config-fields-m2 1.3.0` unter Magento 2.4.9 GA + PHP 8.5 installiert und PHPUnit-Suite grün durchgelaufen. Da der Code unverändert ist (3 commits ahead of 1.3.0 = renovate.json + security.yml, keine `src/`-Änderung), gilt diese Coverage transitiv weiterhin für 1.4.0.

- [x] PR-CI grün (gitleaks, dependency-review, composer-audit)
- [ ] Merge `develop`, dann `develop → master`, Tag `1.4.0`
- [ ] Packagist webhook auto-publish bestätigen
- [ ] Bundle-Module-Constraint später auf `^1.4.0` hochziehen (Folge-Welle DHLGW-1535)