### PR TITLE
ci: drop composer-audit job (TYPO3 workflow incompatible with Magento)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,3 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-
-  composer-audit:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main


### PR DESCRIPTION
## Problem

`composer-audit / Composer Audit` Job in [`.github/workflows/security.yml`](https://github.com/netresearch/config-fields-m2/blob/master/.github/workflows/security.yml#L22-L23) ist seit dem 2026-04-01 ([`84f7eb2`](https://github.com/netresearch/config-fields-m2/commit/84f7eb2)) **bei jedem master-Push rot**. Beispiel-Failure: [run 26753420285](https://github.com/netresearch/config-fields-m2/actions/runs/26753420285).

## Ursache

`netresearch/typo3-ci-workflows/.github/workflows/security.yml@main` ist ein TYPO3-orientierter reusable workflow. Er ruft `composer install` vor dem Audit. Magento-Modul-Repos haben aber Top-Level-Deps `magento/framework`, `magento/module-backend`, `magento/module-config` auf [`repo.magento.com`](https://repo.magento.com) — das braucht Marketplace-Auth (`MAGENTO_REPO_USERNAME` / `MAGENTO_REPO_PASSWORD` als Composer-Auth). Der reusable workflow hat diese Credentials nicht und kann die Pakete nicht auflösen.

```
Problem 1
  - Root composer.json requires magento/framework, it could not be found in any version,
    there may be a typo in the package name.
```

Auf PRs targeting `develop` lief der Workflow nicht (Trigger ist nur `push/pr → main/master`) — daher in der DHLGW-1535 PR #10 nicht sichtbar.

## Lösung

`composer-audit:` Job aus dem workflow entfernen. Verbleibende Security-Coverage:

- `gitleaks` — Secret Scanning
- `dependency-review` — PR only, GitHub's eigener Dependency-Review
- `CodeQL` — separater workflow (codeql.yml)

## Follow-up

Magento-spezifischer reusable audit-Workflow (org-wide `netresearch/magento-ci-workflows`) als separates Ticket einplanen, falls weiterer Audit-Coverage gewünscht. Würde Marketplace-Creds als secret inputs akzeptieren.

## Test plan

- [ ] PR-CI grün (gitleaks, dependency-review, CodeQL)
- [ ] Merge `develop` → `master` Sync, master-Push triggert security.yml ohne fail