### PR TITLE
ci: route composer-audit through magento-ci-workflows reusable (supersedes #11)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       skip-composer-audit: true
 
   magento-composer-audit:
-    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.0
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.1
     secrets:
       MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
       MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,3 +21,11 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    with:
+      skip-composer-audit: true
+
+  magento-composer-audit:
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.0
+    secrets:
+      MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
+      MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       skip-composer-audit: true
 
   magento-composer-audit:
-    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.2
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.3
     secrets:
       MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
       MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       skip-composer-audit: true
 
   magento-composer-audit:
-    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.1
+    uses: netresearch/magento-ci-workflows/.github/workflows/composer-audit.yml@v0.1.2
     secrets:
       MAGENTO_REPO_USERNAME: ${{ secrets.MAGENTO_REPO_USERNAME }}
       MAGENTO_REPO_PASSWORD: ${{ secrets.MAGENTO_REPO_PASSWORD }}


### PR DESCRIPTION
Routes composer-audit through netresearch/magento-ci-workflows v0.1.0 with Marketplace credentials passed as workflow secrets (synced from Vault per CI-390). Supersedes #11. Part of fleet-wide rollout to 15 other Magento module repos.