### PR TITLE
Release 1.4.1 — Tighten PHP version constraint to Magento convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.4.1
+
+### Changed
+
+- Use tilde version range for PHP requirement to match Magento framework convention.
+
 ## 1.4.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "netresearch/config-fields-m2",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "magento2-module",
   "description": "A collection of custom config types for Magento 2 system configuration development.",
   "license": "OSL-3.0",
@@ -14,7 +14,7 @@
     "magento/framework": "^103.0.8",
     "magento/module-backend": "^102.0.8",
     "magento/module-config": "^101.2.8",
-    "php": "^8.3.0"
+    "php": "~8.3.0||~8.4.0||~8.5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
DHLGW-1535 patch: change PHP requirement from `^8.3.0` to `~8.3.0||~8.4.0||~8.5.0` to match Magento framework convention and explicitly enumerate the tested PHP version matrix.