### PR TITLE
ci: adopt canonical php-module template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Managed by netresearch/.github/templates/skill/
+#
+# Declares only the ecosystems every skill consumer is guaranteed to have:
+# github-actions (CI workflows) and composer (every skill repo ships a
+# composer.json for split-licensing / Packagist distribution).
+#
+# npm and devcontainers are OPT-IN: a repo that actually has package.json
+# fixtures (e.g. skills/<name>/references/examples/**) or a devcontainer adds
+# the block below to its own dependabot.yml and lists `.github/dependabot.yml`
+# under `intentional-drift:` in .github/template.yaml so the template sync
+# stops managing the file. Declaring an ecosystem without its manifest makes
+# the Dependabot run fail with `dependency_file_not_found`.
+#
+# Opt-in npm (use Dependabot's plural `directories:` to consolidate multiple
+# fixture dirs into one grouped PR):
+#   - package-ecosystem: npm
+#     directories:
+#       - /skills/<name>/references/examples/<project>
+#     schedule:
+#       interval: weekly
+#       day: monday
+#     open-pull-requests-limit: 5
+#     groups:
+#       npm:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ['*']
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      composer:
+        patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.md', 'docs/**/*', '**/SKILL.md', 'README.md']
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**/*', 'Makefile']
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ['composer.json', 'composer.lock', 'package.json', 'package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock', '.devcontainer/**/*']
+skill:
+  - changed-files:
+      - any-glob-to-any-file: ['skills/**/*', '.claude-plugin/**/*', 'plugin.json']
+evals:
+  - changed-files:
+      - any-glob-to-any-file: ['**/evals/**/*', '**/eval/**/*', '**/*.eval.yaml', '**/*.eval.yml']

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -1,0 +1,11 @@
+# Managed by netresearch/.github/templates/php-module/
+# Drift from the template is blocking CI in this repo (check-template-drift.yml).
+# Record explicit exceptions under intentional-drift[] to unblock.
+#
+# For PHP modules (Magento 2 / Shopware 6 / composer SDKs). CI surface is the
+# security/quality reusables with explicit per-call-site permissions (immune to
+# a restricted default_workflow_permissions). CodeQL is via GitHub default setup
+# (a repo setting), so no codeql.yml here. Add a test workflow per repo as
+# needed and list it under intentional-drift.
+template: php-module
+intentional-drift: []

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,16 @@
+name: Auto-merge dependency PRs
+
+on:
+  # auto-merge only calls `gh pr merge` via the reusable with the base-repo
+  # token; it never checks out or runs PR head code, so pull_request_target
+  # (required for a write token on Dependabot/Renovate fork PRs) is safe here.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -1,0 +1,17 @@
+name: Template Drift
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  drift:
+    uses: netresearch/.github/.github/workflows/check-template-drift.yml@main
+    with:
+      template: php-module
+    permissions:
+      contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,23 @@
+name: OpenSSF Scorecard
+
+# Supply-chain posture scoring (branch protection, pinned actions, token
+# permissions, …). Runs on default-branch push and on a weekly schedule;
+# results upload to the code-scanning dashboard.
+
+on:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scorecard:
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,27 @@
 name: Security
 
+# Aggregated security scans: secret scanning (gitleaks), dependency review on
+# PRs, and a composer audit (every PHP module ships a composer.json).
+#
+# Top-level `permissions: {}` denies everything by default; each reusable
+# caller job re-declares the exact union its reusable's jobs require, so the
+# token passed to each reusable is fully explicit and never relies on the
+# repo default. This is the same pattern proven in netresearch/.github's
+# go-app template (top {} + per-job security-events: write).
+
 on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
+
+permissions: {}
 
 jobs:
   gitleaks:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
     secrets:
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
@@ -21,3 +34,6 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
Migrate CI to the canonical `php-module` template (netresearch/.github): explicit per-call-site permissions on every reusable, drift-enforced. CodeQL via default setup.